### PR TITLE
Allow `None` for max_tokens in local eval

### DIFF
--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -258,9 +258,9 @@ def main():
     parser.add_argument(
         "--max-tokens",
         "-t",
-        type=str,
-        default="1024",
-        help="Maximum number of tokens to generate (use 'None' to unset)",
+        type=int,
+        default=None,
+        help="Maximum number of tokens to generate (unset to use model default)",
     )
     parser.add_argument(
         "--temperature", "-T", type=float, default=None, help="Temperature for sampling"
@@ -291,15 +291,6 @@ def main():
     )
     args = parser.parse_args()
 
-    # Parse optional max_tokens from string input
-    if isinstance(args.max_tokens, str):
-        if args.max_tokens.lower() in ("none", ""):
-            parsed_max_tokens = None
-        else:
-            parsed_max_tokens = int(args.max_tokens)
-    else:
-        parsed_max_tokens = args.max_tokens
-
     eval_environment(
         env=args.env,
         env_args=args.env_args,
@@ -311,7 +302,7 @@ def main():
         num_examples=args.num_examples,
         rollouts_per_example=args.rollouts_per_example,
         max_concurrent_requests=args.max_concurrent_requests,
-        max_tokens=parsed_max_tokens,
+        max_tokens=args.max_tokens,
         temperature=args.temperature,
         verbose=args.verbose,
         save_dataset=args.save_dataset,

--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -26,7 +26,7 @@ def eval_environment(
     num_examples: int,
     rollouts_per_example: int,
     max_concurrent_requests: int,
-    max_tokens: int,
+    max_tokens: int | None,
     temperature: float | None,
     verbose: bool,
     save_dataset: bool,
@@ -258,9 +258,9 @@ def main():
     parser.add_argument(
         "--max-tokens",
         "-t",
-        type=int,
-        default=1024,
-        help="Maximum number of tokens to generate",
+        type=str,
+        default="1024",
+        help="Maximum number of tokens to generate (use 'None' to unset)",
     )
     parser.add_argument(
         "--temperature", "-T", type=float, default=None, help="Temperature for sampling"
@@ -291,6 +291,15 @@ def main():
     )
     args = parser.parse_args()
 
+    # Parse optional max_tokens from string input
+    if isinstance(args.max_tokens, str):
+        if args.max_tokens.lower() in ("none", ""):
+            parsed_max_tokens = None
+        else:
+            parsed_max_tokens = int(args.max_tokens)
+    else:
+        parsed_max_tokens = args.max_tokens
+
     eval_environment(
         env=args.env,
         env_args=args.env_args,
@@ -302,7 +311,7 @@ def main():
         num_examples=args.num_examples,
         rollouts_per_example=args.rollouts_per_example,
         max_concurrent_requests=args.max_concurrent_requests,
-        max_tokens=args.max_tokens,
+        max_tokens=parsed_max_tokens,
         temperature=args.temperature,
         verbose=args.verbose,
         save_dataset=args.save_dataset,


### PR DESCRIPTION
## Description
This PR addresses the need to specify `None` for `max_tokens` when evaluating against local inference servers. By allowing `max_tokens` to be unset (passed as `None`), the system will omit the `max_tokens` parameter from the OpenAI API call. This enables local servers to generate responses until their maximum context length, preventing errors that occur when a fixed `max_tokens` value, combined with the prompt, exceeds the server's actual context limit. This change aligns with how generic OpenAI clients handle optional parameters.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
- [x] All existing tests pass
- [ ] New tests have been added to cover the changes
- [x] Tests have been run locally with `python -m pytest tests/`

### Test Coverage
- Current coverage: ___%
- Coverage after changes: ___%

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
Users can now specify `--max-tokens None` or `-t None` when running `vf-eval`. This will cause the `max_tokens` (or `max_completion_tokens` for chat models) parameter to be entirely omitted from the API request, allowing the inference server to use its default behavior for response generation.

---
<a href="https://cursor.com/background-agent?bcId=bc-07fe7205-9127-49bd-8216-302d0cdd3f39">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-07fe7205-9127-49bd-8216-302d0cdd3f39">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

