### PR TITLE
Investigate sampling args for response format

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -151,21 +151,23 @@ class MockAsyncOpenAI:
             response_data = self.chat_completions[key]
         else:
             response_data = {
-                "content": self.default_chat_response,
+                "parsed": self.default_chat_response,
                 "finish_reason": "stop",
                 "tool_calls": None,
             }
 
         # Create mock response with .parsed on message
-        from openai.types.chat.chat_completion import ChatCompletion, Choice
-        from openai.types.chat.chat_completion_message import ChatCompletionMessage
+        from openai.types.chat.parsed_chat_completion import (
+            ParsedChatCompletion,
+            ParsedChoice,
+            ParsedChatCompletionMessage,
+        )
 
-        mock_response = MagicMock(spec=ChatCompletion)
-        mock_choice = MagicMock(spec=Choice)
-        mock_message = MagicMock(spec=ChatCompletionMessage)
+        mock_response = MagicMock(spec=ParsedChatCompletion)
+        mock_choice = MagicMock(spec=ParsedChoice)
+        mock_message = MagicMock(spec=ParsedChatCompletionMessage)
 
-        mock_message.content = response_data["content"]
-        mock_message.parsed = response_data["content"]
+        mock_message.parsed = response_data["parsed"]
         mock_message.role = "assistant"
         mock_message.tool_calls = response_data.get("tool_calls", None)
         mock_choice.message = mock_message
@@ -175,7 +177,7 @@ class MockAsyncOpenAI:
         mock_response.choices = [mock_choice]
         mock_response.id = "test-id"
         mock_response.model = "test-model"
-        mock_response.object = "chat.completion"
+        mock_response.object = "chat.completion.parsed"
 
         return mock_response
 

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import AsyncMock, Mock
 
+from pydantic import BaseModel
 import pytest
 from datasets import Dataset
 
@@ -216,10 +217,19 @@ class TestEnvironmentBase:
                 "function": {
                     "name": "calculator",
                     "description": "calc",
-                    "parameters": {"type": "object", "properties": {}},
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "x": {"type": "number"},
+                            "y": {"type": "number"},
+                        },
+                    },
                 },
             }
         ]
+
+        class CalculatorResponse(BaseModel):
+            answer: int
 
         response = await env.get_model_response(
             prompt=prompt,
@@ -227,7 +237,7 @@ class TestEnvironmentBase:
             model="test-model",
             message_type="chat",
             oai_tools=tools,
-            sampling_args={"response_format": object},
+            sampling_args={"response_format": CalculatorResponse},
         )
 
         assert hasattr(response, "choices")

--- a/tests/test_judge_rubric.py
+++ b/tests/test_judge_rubric.py
@@ -131,7 +131,7 @@ async def test_response_format_validation_accepts_pydantic_model():
         parser=Parser(),
         judge_client=client,
         judge_model="test-model",
-        response_format=JudgeResponse,
+        judge_sampling_args={"response_format": JudgeResponse},
     )
 
     prompt = "P"

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -236,7 +236,9 @@ class Environment(ABC):
                         c = m.get("content")  # type: ignore[assignment]
                         if isinstance(c, list):
                             for p in c:
-                                if isinstance(p, dict) and str(p.get("type", "")).startswith("input_audio"):
+                                if isinstance(p, dict) and str(
+                                    p.get("type", "")
+                                ).startswith("input_audio"):
                                     has_audio = True
                                     break
                         if has_audio:
@@ -244,40 +246,32 @@ class Environment(ABC):
                 except Exception:
                     has_audio = False
                 if has_audio and "modalities" not in clean_sampling_args:
-                    clean_sampling_args = {**clean_sampling_args, "modalities": ["text"]}
+                    clean_sampling_args = {
+                        **clean_sampling_args,
+                        "modalities": ["text"],
+                    }
 
-                if response_format is not None:
-                    # Route to parse API when a response_format is provided, forwarding tools if any
-                    if oai_tools:
-                        response = await client.chat.completions.parse(
-                            model=model,
-                            messages=prompt,  # type: ignore
-                            tools=oai_tools,
-                            response_format=response_format,
-                            **clean_sampling_args,
-                        )
-                    else:
-                        response = await client.chat.completions.parse(
-                            model=model,
-                            messages=prompt,  # type: ignore
-                            response_format=response_format,
-                            **clean_sampling_args,
-                        )
-                else:
-                    if oai_tools:
-                        response = await client.chat.completions.create(
-                            model=model,
-                            messages=prompt,  # type: ignore
-                            tools=oai_tools,
-                            **clean_sampling_args,
-                        )
-                    else:
-                        response = await client.chat.completions.create(
-                            model=model,
-                            messages=prompt,  # type: ignore
-                            **clean_sampling_args,
-                        )
+                # Build common args for chat completion request
+                method = client.chat.completions.create
+                args = {
+                    "model": model,
+                    "messages": prompt,  # type: ignore
+                    **clean_sampling_args,
+                }
+
+                # Add tools if provided
+                if oai_tools:
+                    args["tools"] = oai_tools
+
+                # Add response_format if provided
+                if response_format:
+                    args["response_format"] = response_format
+                    # Use parse API if response_format provided, otherwise default
+                    method = client.chat.completions.parse
+
+                response = await method(**args)
                 return response
+
             elif message_type == "completion":
                 if oai_tools:
                     raise ValueError(

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -224,6 +224,8 @@ class Environment(ABC):
         ):
             sampling_args.pop("max_completion_tokens")
         clean_sampling_args = {k: v for k, v in sampling_args.items() if v is not None}
+        # Extract response_format if provided via sampling_args
+        response_format = clean_sampling_args.pop("response_format", None)
         try:
             if message_type == "chat":
                 assert isinstance(prompt, list)
@@ -244,19 +246,37 @@ class Environment(ABC):
                 if has_audio and "modalities" not in clean_sampling_args:
                     clean_sampling_args = {**clean_sampling_args, "modalities": ["text"]}
 
-                if oai_tools:
-                    response = await client.chat.completions.create(
-                        model=model,
-                        messages=prompt,  # type: ignore
-                        tools=oai_tools,
-                        **clean_sampling_args,
-                    )
+                if response_format is not None:
+                    # Route to parse API when a response_format is provided, forwarding tools if any
+                    if oai_tools:
+                        response = await client.chat.completions.parse(
+                            model=model,
+                            messages=prompt,  # type: ignore
+                            tools=oai_tools,
+                            response_format=response_format,
+                            **clean_sampling_args,
+                        )
+                    else:
+                        response = await client.chat.completions.parse(
+                            model=model,
+                            messages=prompt,  # type: ignore
+                            response_format=response_format,
+                            **clean_sampling_args,
+                        )
                 else:
-                    response = await client.chat.completions.create(
-                        model=model,
-                        messages=prompt,  # type: ignore
-                        **clean_sampling_args,
-                    )
+                    if oai_tools:
+                        response = await client.chat.completions.create(
+                            model=model,
+                            messages=prompt,  # type: ignore
+                            tools=oai_tools,
+                            **clean_sampling_args,
+                        )
+                    else:
+                        response = await client.chat.completions.create(
+                            model=model,
+                            messages=prompt,  # type: ignore
+                            **clean_sampling_args,
+                        )
                 return response
             elif message_type == "completion":
                 if oai_tools:


### PR DESCRIPTION
## Description
Refactors `JudgeRubric` to remove the dedicated `response_format` parameter. `response_format` is now passed as part of the `judge_sampling_args` dictionary, aligning with the goal of unifying generation configuration parameters.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
- [x] All existing tests pass
- [x] New tests have been added to cover the changes (existing test updated to reflect new parameter passing)
- [x] Tests have been run locally with `uv run pytest`

### Test Coverage
- Current coverage: ___%
- Coverage after changes: ___%

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
This change implements the suggestion to pass `response_format` through `sampling_args` for `JudgeRubric`, removing the explicit `response_format` parameter from its constructor. This unifies how generation parameters are configured.

---
<a href="https://cursor.com/background-agent?bcId=bc-c8338387-648c-4559-bc03-45a88c72c681"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c8338387-648c-4559-bc03-45a88c72c681"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

